### PR TITLE
[JFR] Fix object profiling stacktrace problem on aarch64 platform

### DIFF
--- a/test/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java
+++ b/test/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java
@@ -175,14 +175,14 @@ public class TestOptoObjectAllocationsSampling {
                     Asserts.assertTrue(!clazz.isArray());
                     Asserts.assertTrue(objectSize > 0);
                     Asserts.assertTrue(topFrame.getLineNumber() > 0);
-                    Asserts.assertTrue(topFrame.getBytecodeIndex() > 0);
+                    Asserts.assertEquals(7, topFrame.getBytecodeIndex());
                     countOfInstanceObject++;
                 } else if (className.equals(arrayObjectClassName)) {
                     Asserts.assertTrue(clazz.isArray());
                     Asserts.assertTrue(objectSize == RECORDED_ARRAY_CLASS_OBJECT_SIZE_MAGIC_CODE);
                     countOfArrayObject++;
                     Asserts.assertTrue(topFrame.getLineNumber() > 0);
-                    Asserts.assertTrue(topFrame.getBytecodeIndex() > 0);
+                    Asserts.assertEquals(1, topFrame.getBytecodeIndex());
                 }
             }
             System.out.format("Total Event Count: %d, EventOptoInstanceObjectAllocaiton Count: %d, EventOptoArrayObjectAllocation Count: %d\n", events.size(), countOfInstanceObject, countOfArrayObject);


### PR DESCRIPTION
Summary:
1. Use CallStaticJavaNode to invoke jfr_fast_object_alloc_C so that
last_java_sp is set properly
2. Remove StackWalkMode and _cached_top_frame_bci

Test Plan:
test/jdk/jfr/event/objectsprofiling/TestOptoObjectAllocationsSampling.java

Reviewed-by: kelthuzadx, kuaiwei, sandlerwang, zhengxiaolinX

Issue: https://github.com/alibaba/dragonwell11/issues/189