### PR TITLE
[Wisp] fix LoadClassInnerWispGuard and WispControlGroupCpuTest

### DIFF
--- a/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
+++ b/src/linux/classes/com/alibaba/wisp/engine/WispEngine.java
@@ -162,6 +162,7 @@ public class WispEngine extends AbstractExecutorService {
             new ConcurrentSkipListMap<>().keySet().iterator();
             WispCarrier carrier = WispCarrier.current();
             carrier.addTimer(System.nanoTime() + Integer.MAX_VALUE, TimeOut.Action.JDK_UNPARK);
+            WispCarrier.current().current.timeOut.doAction();
             carrier.cancelTimer();
             carrier.createResumeEntry(new WispTask(carrier, null, false, false));
             // preload classes used by by constraintInResourceContainer method.

--- a/test/com/alibaba/wisp2/WispControlGroupCpuTest.java
+++ b/test/com/alibaba/wisp2/WispControlGroupCpuTest.java
@@ -46,6 +46,7 @@ public class WispControlGroupCpuTest {
         createMethod0.setAccessible(true);
         createMethod1.setAccessible(true);
 
+        taskFactory(10_000_000).call(); // warmup
         Callable<Long> task0 = taskFactory(2_000_000);
         Callable<Long> task1 = taskFactory(2_000_000);
         Callable<Long> task2 = taskFactory(2_000_000);
@@ -65,9 +66,9 @@ public class WispControlGroupCpuTest {
         Long duration1 = future1.get();
         Long duration2 = future2.get();
         Long duration3 = future3.get();
-        double ratio = (double) duration1.longValue() / duration0.longValue();
-        assertLT(Math.abs(ratio - 0.5), 0.1, "deviation is out of reasonable scope");
-        ratio = (double) duration3.longValue() / duration2.longValue();
-        assertLT(Math.abs(ratio - 0.5), 0.1, "deviation is out of reasonable scope");
+        double ratio = (double) duration1 / duration0;
+        assertLT(Math.abs(ratio - 0.5), 0.1, "deviation is out of reasonable scope " + ratio);
+        ratio = (double) duration3 / duration2;
+        assertLT(Math.abs(ratio - 0.5), 0.1, "deviation is out of reasonable scope " + ratio);
     }
 }


### PR DESCRIPTION
Summary:
- Pre-load switch table class in TimeOut::doAction
- Add warmup for WispControlGroupCpuTest

Test Plan: jtreg jdk/test/com/alibaba/wisp{,2}

Reviewed-by: zhengxiaolinX, joeylee.lz

Issue: alibaba/dragonwell8#279